### PR TITLE
Upgrade guzzle to version ~6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-php: [5.4, 5.5, 5.6, hhvm]
+php: [5.5, 5.6, 7.0, hhvm]
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.4.0",
         "behat/behat": "~3.0.6",
-        "guzzlehttp/guzzle": "~5.0",
+        "guzzlehttp/guzzle": "~6.0",
         "justinrainbow/json-schema": "~1.3",
         "seromenho/xml-validator": "~v1.0"
     },

--- a/src/Arachne/Http/Response/Guzzle.php
+++ b/src/Arachne/Http/Response/Guzzle.php
@@ -11,7 +11,7 @@
 
 namespace Arachne\Http\Response;
 
-use GuzzleHttp\Message\ResponseInterface as Response;
+use GuzzleHttp\Psr7\Response;
 
 /**
  * Class Guzzle
@@ -48,6 +48,6 @@ class Guzzle implements ResponseInterface
      */
     public function getHeader($name)
     {
-        return $this->response->getHeader($name);
+        return $this->response->getHeaderLine($name);
     }
 }


### PR DESCRIPTION
Hi Wojtek, it's me again :-) 

In order to use your library in a project which uses guzzle 6, I needed to upgrade the guzzle dependency of your library which is maybe also useful for others.

