### PR TITLE
XmlSchema validation fixed for the case when xml was invalid

### DIFF
--- a/src/Arachne/Validation/Schema/XmlSchema.php
+++ b/src/Arachne/Validation/Schema/XmlSchema.php
@@ -38,7 +38,7 @@ class XmlSchema implements ValidatorInterface
             if(!$validator->isValid()){
                 $errors = [];
                 foreach ($validator->getErrors() as $error) {
-                    $errors[] = $error['message'];
+                    $errors[] = $error->message;
                 }
 
                 throw new Exception\InvalidXml(implode(', ', $errors));


### PR DESCRIPTION
The xml schema validator was returning an Object not an array. Therefore the code was crashing.

I wanted to write a test but due to the fact the implementation is coupled to the libarary (Object creation) I decided to do the quick fix only.

Would be great if you could accept this fix. Thanks.